### PR TITLE
Make asap work in browsers as well as node.

### DIFF
--- a/asap.js
+++ b/asap.js
@@ -1,4 +1,3 @@
-
 // Use the fastest possible means to execute a task in a future turn
 // of the event loop.
 
@@ -109,5 +108,8 @@ function asap(task) {
     }
 };
 
-module.exports = asap;
+if (typeof exports === "object") {
+    module.exports = asap;
+}
+
 


### PR DESCRIPTION
I converted ProcScript to use asap but got an exception when testing it in the Chrome browser.  I borrowed the code that checks for module support from the old _nextTick code.
