### PR TITLE
Tests does not need `asap.onerror`

### DIFF
--- a/asap.js
+++ b/asap.js
@@ -39,13 +39,13 @@ function flush() {
                 // listening process.on("uncaughtException") or domain("error").
                 requestFlush();
 
-                throw e;
+                asap._throw(e);
 
             } else {
                 // In browsers, uncaught exceptions are not fatal.
                 // Re-throw them asynchronously to avoid slow-downs.
                 setTimeout(function () {
-                    throw e;
+                    asap._throw(e);
                 }, 0);
             }
         }
@@ -109,6 +109,11 @@ function asap(task) {
         requestFlush();
         flushing = true;
     }
+};
+
+// Overridden by tests.
+asap._throw = function (e) {
+    throw e;
 };
 
 module.exports = asap;

--- a/test/browser-domain.js
+++ b/test/browser-domain.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var asap = require("..");
 var _ = require("lodash");
 var EventEmitter = require("events").EventEmitter;
 
@@ -21,20 +22,13 @@ exports.create = function () {
     return activeDomain;
 };
 
-global.asap = _.wrap(asap, function (originalAsap, task) {
-    originalAsap(function () {
-        try {
-            task();
-
-        } catch (error) {
-            if (activeDomain) {
-                activeDomain.emit("error", error);
-            } else {
-                throw error;
-            }
-        }
-    });
-});
+asap._throw = function (error) {
+    if (activeDomain) {
+        activeDomain.emit("error", error);
+    } else {
+        throw error;
+    }
+};
 
 exports.teardown = function () {
     activeDomain = null;

--- a/test/domain-implementation.js
+++ b/test/domain-implementation.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var asap = require("..");
 var _ = require("lodash");
 
 // This is a reliable test for true Node.js, avoiding false positives for e.g. Browserify's emulation environment.
@@ -27,17 +28,10 @@ if (isNodeJS) {
             originalRemove.call(process, eventName, listener._asap_wrapper_ || listener);
         });
 
-        global.asap = _.wrap(asap, function (originalAsap, task) {
-            originalAsap(function () {
-                try {
-                    task();
-
-                } catch (error) {
-                    errorsToIgnore.push(error);
-                    throw error;
-                }
-            });
-        });
+        asap._throw = function (error) {
+            errorsToIgnore.push(error);
+            throw error;
+        };
 
         afterEach(function () {
             errorsToIgnore = [];

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,6 +1,6 @@
 "use strict";
 
-global.asap = require("..");
+var asap = require("..");
 var assert = require("assert");
 var _ = require("lodash");
 var domain = require("./domain-implementation");


### PR DESCRIPTION
In #15, `asap.onerror` is introduced, but it is questionably required.

To avoid to have #15 stuck because of eventual long-standing debate about the not strictly correlated `asap.onerror`, we should remove it from there, and eventually consider its addition with a separate issue/discussion.
