### PR TITLE
 Test-only `asap.setOnError` instead of public `asap.onerror`

### DIFF
--- a/asap.js
+++ b/asap.js
@@ -39,22 +39,14 @@ function flush() {
                 // listening process.on("uncaughtException") or domain("error").
                 requestFlush();
 
-                if (asap.onerror) {
-                    asap.onerror(e);
-                    return;
-                } else {
-                    throw e;
-                }
+                throw e;
+
             } else {
                 // In browsers, uncaught exceptions are not fatal.
                 // Re-throw them asynchronously to avoid slow-downs.
-                if (asap.onerror) {
-                    asap.onerror(e);
-                } else {
-                    setTimeout(function () {
-                        throw e;
-                    }, 0);
-                }
+                setTimeout(function () {
+                    throw e;
+                }, 0);
             }
         }
     }

--- a/test/asap-implementation.js
+++ b/test/asap-implementation.js
@@ -1,0 +1,38 @@
+
+var ASAP = require("..");
+
+var onerror;
+
+function asap(task) {
+	return ASAP(function () {
+		if (onerror) {
+			try {
+				task();
+
+			} catch (e) {
+				onerror(e);
+			}
+
+		} else {
+			task();
+		}
+	});
+}
+
+asap.setOnError = function (f) {
+	if (onerror) {
+		throw new Error("onerror already setted");
+	}
+
+	if (typeof f !== "function") {
+		throw new TypeError("not a function");
+	}
+
+	onerror = f;
+};
+
+for (var key in ASAP) {
+	asap[key] = ASAP[key];
+}
+
+module.exports = asap;

--- a/test/browser-domain.js
+++ b/test/browser-domain.js
@@ -1,32 +1,35 @@
 "use strict";
 
 var EventEmitter = require("events").EventEmitter;
-var asap = require("..");
+var asap = require("./asap-implementation");
 
 // This is a very rudimentary domain shim meant only to work with asap and with asap's tests. Unlike the real domain
 // module, it requires manual teardown. It hooks in to `asap.onerror`.
 
-var domainIsActive = false;
+var activeDomain = null;
 
 exports.create = function () {
-    if (domainIsActive) {
+    if (activeDomain) {
         throw new Error("A domain is already active! You need to tear it down first!");
     }
-    domainIsActive = true;
 
-    var d = new EventEmitter();
-    d.run = function (f) {
+    activeDomain = new EventEmitter();
+    activeDomain.run = function (f) {
         f();
     };
 
-    asap.onerror = function (error) {
-        d.emit("error", error);
-    };
-
-    return d;
+    return activeDomain;
 };
 
+asap.setOnError(function (error) {
+    if (activeDomain) {
+        activeDomain.emit("error", error);
+
+    } else {
+        throw error;
+    }
+});
+
 exports.teardown = function () {
-    asap.onerror = null;
-    domainIsActive = false;
+    activeDomain = null;
 };

--- a/test/domain-implementation.js
+++ b/test/domain-implementation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var asap = require("..");
+var asap = require("./asap-implementation");
 var _ = require("lodash");
 
 // This is a reliable test for true Node.js, avoiding false positives for e.g. Browserify's emulation environment.
@@ -28,10 +28,10 @@ if (isNodeJS) {
             originalRemove.call(process, eventName, listener._asap_wrapper_ || listener);
         });
 
-        asap.onerror = function (error) {
+        asap.setOnError(function (error) {
             errorsToIgnore.push(error);
             throw error;
-        };
+        });
 
         afterEach(function () {
             errorsToIgnore = [];

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var asap = require("..");
+var asap = require("./asap-implementation");
+var domain = require("./domain-implementation");
 var assert = require("assert");
 var _ = require("lodash");
-var domain = require("./domain-implementation");
 
 var MAX_RECURSION = 4000;
 var WAIT_FOR_NORMAL_CASE = 100;


### PR DESCRIPTION
This is a possible strategy for removing `asap.onerror` from #15.
