### PR TITLE
Make tasks callables

### DIFF
--- a/asap.js
+++ b/asap.js
@@ -28,7 +28,7 @@ function flush() {
         head.task = void 0;
 
         try {
-            task();
+            task.call();
 
         } catch (e) {
             if (isNodeJS) {


### PR DESCRIPTION
Previously, tasks needed to be functions. Now they may be any object
that implements "call". This will open the possibility of enqueing a
reusable callable object instead of a closure.
