### PR TITLE
Add the ability to mark the top level

### DIFF
--- a/raw.js
+++ b/raw.js
@@ -14,13 +14,17 @@ var hasSetImmediate = typeof setImmediate === "function";
 // call `rawAsap.requestFlush` if an exception is thrown.
 module.exports = rawAsap;
 function rawAsap(task) {
-    if (!queue.length) {
+    if (!flushing) {
         requestFlush();
         flushing = true;
     }
     // Avoids a function call
     queue[queue.length] = task;
 }
+module.exports.markFlushing = function () {
+  flushing = true;
+};
+module.exports.flush = flush;
 
 var queue = [];
 // Once a flush has been requested, no further calls to `requestFlush` are


### PR DESCRIPTION
This is a request for comments.  If people think it's worthwhile and agree with the proposed API, I'll add it to the other interfaces.

The idea is that you could do something like:

``` js
var fs = require('fs');
var asap = require('asap/raw');

var readFile = fs.readFile;
fs.readFile = function (filename, encoding, callback) {
  if (callback === undefined) {
    callback = encoding;
    encoding = undefined;
  }
  readFile(filename, encoding, function (err, res) {
    asap.markFlushing();
    callback.apply(this, arguments);
    asap.flush();
  });
};
```

This avoids an extra nextTick call when we know we are already at the top of the stack.
