### PR TITLE
Fix browserifying sub-files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "main": "./asap.js",
   "browser": {
+    "./asap": "./browser-asap.js",
     "./asap.js": "./browser-asap.js",
+    "./raw": "./browser-raw.js",
     "./raw.js": "./browser-raw.js",
     "./test/domain.js": "./test/browser-domain.js"
   },


### PR DESCRIPTION
This works around a problem in browserify which means that you would only get the browser versions of files if you do `require('asap/raw.js')` but not if you do `require('asap/raw')`.