### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "task",
     "queue"
   ],
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/kriskowal/asap/raw/master/LICENSE.md"
-  },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/kriskowal/asap.git"


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)