### PR TITLE
Fix browserify and webpack bundling problems.

### DIFF
--- a/browser-raw.js
+++ b/browser-raw.js
@@ -76,9 +76,9 @@ function flush() {
 
 // Safari 6 and 6.1 for desktop, iPad, and iPhone are the only browsers that
 // have WebKitMutationObserver but not un-prefixed MutationObserver.
-// Must use `global` instead of `window` to work in both frames and web
-// workers. `global` is a provision of Browserify, Mr, Mrs, or Mop.
-var BrowserMutationObserver = global.MutationObserver || global.WebKitMutationObserver;
+var BrowserMutationObserver = global ?
+    (global.MutationObserver || global.WebKitMutationObserver) :
+    (window.MutationObserver || window.WebKitMutationObserver);
 
 // MutationObservers are desirable because they have high priority and work
 // reliably everywhere they are implemented.


### PR DESCRIPTION
I had a problem with using this library as a dependency of other packages.
This fix solve the problem and all tests are passed succesfully.