### PR TITLE
Fix asap browser dependency in react-native env.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "./raw.js": "./browser-raw.js",
     "./test/domain.js": "./test/browser-domain.js"
   },
+  "react-native": {
+    "domain": false
+  },
   "files": [
     "raw.js",
     "asap.js",


### PR DESCRIPTION
Lots of people, including myself, hit a roadblock importing asap. This fixes it!
Related issues:
https://github.com/kriskowal/asap/issues/64
https://github.com/facebook/react-native/issues/3463
https://github.com/facebook/react-native/pull/2208
https://github.com/Netflix/falcor/issues/603